### PR TITLE
Extend Gradle integration test to check checksums and metadata marker

### DIFF
--- a/src/test/resources/com/fasterxml/jackson/integtest/gradle/build.gradle.kts
+++ b/src/test/resources/com/fasterxml/jackson/integtest/gradle/build.gradle.kts
@@ -13,12 +13,11 @@ val modulesWithoutGradleMetadata = listOf(
 )
 
 dependencies {
-    implementation(platform("com.fasterxml.jackson:jackson-bom:+"))
+    // implementation(platform("com.fasterxml.jackson:jackson-bom:+"))
 
     // 28-Apr-2023, tatu: Uncomment following (and comment ^^^) to test SNAPSHOT versions
-    // implementation(platform("com.fasterxml.jackson:jackson-bom:2.15.1-SNAPSHOT"))
-    // repositories.maven("https://oss.sonatype.org/content/repositories/snapshots")
-    // repositories.mavenCentral()
+    implementation(platform("com.fasterxml.jackson:jackson-bom:2.19.0-SNAPSHOT"))
+    repositories.maven("https://oss.sonatype.org/content/repositories/snapshots")
 }
 
 repositories.mavenCentral()

--- a/src/test/resources/com/fasterxml/jackson/integtest/gradle/build.gradle.kts
+++ b/src/test/resources/com/fasterxml/jackson/integtest/gradle/build.gradle.kts
@@ -87,7 +87,9 @@ tasks.register("checkMetadata") {
         }
 
         val checksumsFromFile = checksumFiles.associate { it.name.substringBeforeLast("-") to it.readText() }
-        val checksumsFromMetadata = gradleMetadataFiles.associate { it.name.substringBeforeLast("-") to it.readText().lines().first { it.contains("\"md5\"") }.substringAfterLast(": \"").replace("\"", "") }
+        val checksumsFromMetadata = gradleMetadataFiles.associate { it.name.substringBeforeLast("-") to it.readText().lines().first {
+            it.contains("\"md5\"") }.substringAfterLast(": \"").replace("\"", "").padStart(32, '0')
+        }
         val checksumsDiff = checksumsFromFile.filter { (k,v) -> checksumsFromMetadata[k] != v }
         if (checksumsDiff.isNotEmpty()) {
             message += "Checksums in Gradle Metadata are wrong:\n  - ${checksumsDiff.keys.joinToString("\n  - ")}\n\n"


### PR DESCRIPTION
Validate that the checksums for the Jar in the `.module` file corresponds to the actual checksum of the Jar.

This is not correct right now for some modules, because the Jar is modified by other plugins (e.g. moditec) after the Gradle metadata plugin computed size and checksums.

Checks what is reported here: https://github.com/FasterXML/jackson-databind/issues/4985