### PR TITLE
Add cacheDynamicVersionsFor(0, "seconds") to Gradle metadata test

### DIFF
--- a/src/test/resources/com/fasterxml/jackson/integtest/gradle/build.gradle.kts
+++ b/src/test/resources/com/fasterxml/jackson/integtest/gradle/build.gradle.kts
@@ -26,6 +26,10 @@ dependencies {
 
 repositories.mavenCentral()
 
+configurations.all {
+    resolutionStrategy.cacheDynamicVersionsFor(0, "seconds") // always refresh SNAPSHOTs
+}
+
 // (miss-)use a component metadata rule to collect all entries from the BOM
 val allJacksonModule = mutableListOf<String>()
 dependencies.components.withModule("com.fasterxml.jackson:jackson-bom") {


### PR DESCRIPTION
See: https://github.com/FasterXML/jackson-integration-tests/issues/27#issuecomment-2741057908