### PR TITLE
Gradle test: cacheDynamicVersionsFor -> cacheChangingModulesFor

### DIFF
--- a/src/test/resources/com/fasterxml/jackson/integtest/gradle/build.gradle.kts
+++ b/src/test/resources/com/fasterxml/jackson/integtest/gradle/build.gradle.kts
@@ -35,7 +35,7 @@ repositories.mavenCentral()
 configurations.all {
     // 23-Mar-2025: [#27] Reduce default snapshot TTL from 24h to none, to avoid
     //    failing (or passing, for that matter) on stale snapshots
-    resolutionStrategy.cacheDynamicVersionsFor(0, "seconds") // always refresh SNAPSHOTs
+    resolutionStrategy.cacheChangingModulesFor(0, "seconds") // always refresh SNAPSHOTs
 }
 
 // (miss-)use a component metadata rule to collect all entries from the BOM


### PR DESCRIPTION
For SNAPSHOT we need to use 'cacheChangingModulesFor' as it is considered a fixed version by Gradle that can change.
'cacheDynamicVersionsFor' only works for not-fixed version notations like '+'.

----

@cowtowncoder Sorry I mix these up all the time. The thing we had never worked 🙈 and that's probably why you were fighting with this.